### PR TITLE
feat(shared-hooks): add rxjs hooks

### DIFF
--- a/libs/shared/hooks/.babelrc
+++ b/libs/shared/hooks/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "@nx/react/babel",
+      {
+        "runtime": "automatic",
+        "useBuiltIns": "usage"
+      }
+    ]
+  ],
+  "plugins": []
+}

--- a/libs/shared/hooks/README.md
+++ b/libs/shared/hooks/README.md
@@ -1,0 +1,7 @@
+# hooks
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test hooks` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/shared/hooks/eslint.config.cjs
+++ b/libs/shared/hooks/eslint.config.cjs
@@ -1,0 +1,12 @@
+const nx = require('@nx/eslint-plugin');
+const baseConfig = require('../../../eslint.config.cjs');
+
+module.exports = [
+  ...baseConfig,
+  ...nx.configs['flat/react'],
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    // Override or add rules here
+    rules: {},
+  },
+];

--- a/libs/shared/hooks/project.json
+++ b/libs/shared/hooks/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "hooks",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/shared/hooks/src",
+  "projectType": "library",
+  "tags": [],
+  "// targets": "to see all targets run: nx show project hooks --web",
+  "targets": {}
+}

--- a/libs/shared/hooks/src/index.ts
+++ b/libs/shared/hooks/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/useObservableState';

--- a/libs/shared/hooks/src/lib/useObservableState.ts
+++ b/libs/shared/hooks/src/lib/useObservableState.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+export function useObservableState<T>(observable: Observable<T>): T | undefined;
+export function useObservableState<T>(
+  observable: Observable<T>,
+  initialValue: T
+): T;
+export function useObservableState<T>(
+  observable: Observable<T>,
+  initialValue?: T
+): T | undefined {
+  // Determine the initial state:
+  // - Use explicit initialValue if provided.
+  // - If no initialValue and observable is BehaviorSubject, use its current value.
+  // - Otherwise, start as undefined (matching the overload).
+  const getInitialState = (): T | undefined => {
+    if (initialValue !== undefined) {
+      return initialValue;
+    }
+    if (observable instanceof BehaviorSubject) {
+      return observable.getValue();
+    }
+    return undefined;
+  };
+
+  // Use a function for lazy initialization of state
+  const [value, setValue] = useState<T | undefined>(getInitialState);
+
+  useEffect(() => {
+    const subscription = observable.subscribe(setValue);
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [observable]);
+
+  // Simply return the current state value. The overloads handle the external typing.
+  return value;
+}

--- a/libs/shared/hooks/src/lib/useSubscription.ts
+++ b/libs/shared/hooks/src/lib/useSubscription.ts
@@ -33,13 +33,6 @@ export function useSubscription<T>(
   const latestErrorRef = useRef(error);
   const latestCompleteRef = useRef(complete);
 
-  // Update refs on every render
-  useEffect(() => {
-    latestObserverOrNextRef.current = observerOrNext;
-    latestErrorRef.current = error;
-    latestCompleteRef.current = complete;
-  });
-
   useEffect(() => {
     let actualObserver: Observer<T>;
 

--- a/libs/shared/hooks/src/lib/useSubscription.ts
+++ b/libs/shared/hooks/src/lib/useSubscription.ts
@@ -1,0 +1,53 @@
+import { useRef, useEffect } from 'react'; // Import useRef
+import { Observable, Subscription } from 'rxjs';
+
+type NextFunction<T> = (value: T) => void;
+type ErrorFunction = (error: any) => void;
+type CompleteFunction = () => void;
+type Observer<T> = {
+  next?: NextFunction<T>;
+  error?: ErrorFunction;
+  complete?: CompleteFunction;
+};
+
+export function useSubscription<T>(
+  observable: Observable<T>,
+  next: NextFunction<T>, // This overload signature is not compatible with its implementation signature.
+  error?: ErrorFunction,
+  complete?: CompleteFunction
+): React.RefObject<Subscription | undefined>;
+export function useSubscription<T>(
+  observable: Observable<T>,
+  observer: Observer<T>
+): React.RefObject<Subscription | undefined>;
+export function useSubscription<T>(
+  observable: Observable<T>,
+  observerOrNext: Observer<T> | NextFunction<T>,
+  error?: ErrorFunction,
+  complete?: CompleteFunction
+): React.RefObject<Subscription | undefined> {
+  // Implementation return type matches overloads
+  const subscriptionRef = useRef<Subscription | undefined>(undefined);
+
+  useEffect(() => {
+    let actualObserver: Observer<T>;
+
+    // Check which overload was used based on the type of the second argument
+    if (typeof observerOrNext === 'function') {
+      // First overload was used: (observable, next, error?, complete?)
+      actualObserver = { next: observerOrNext, error, complete };
+    } else {
+      // Second overload was used: (observable, observer)
+      actualObserver = observerOrNext;
+    }
+
+    subscriptionRef.current = observable.subscribe(actualObserver);
+
+    return () => {
+      subscriptionRef.current?.unsubscribe();
+    };
+    // Dependency array needs to include all potential inputs that affect the subscription
+  }, [observable, observerOrNext, error, complete]);
+
+  return subscriptionRef;
+}

--- a/libs/shared/hooks/tsconfig.json
+++ b/libs/shared/hooks/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowJs": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "extends": "../../../tsconfig.base.json"
+}

--- a/libs/shared/hooks/tsconfig.lib.json
+++ b/libs/shared/hooks/tsconfig.lib.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": [
+      "node",
+      "@nx/react/typings/cssmodule.d.ts",
+      "@nx/react/typings/image.d.ts"
+    ]
+  },
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.js",
+    "src/**/*.test.js",
+    "src/**/*.spec.jsx",
+    "src/**/*.test.jsx"
+  ],
+  "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
+}

--- a/nx.json
+++ b/nx.json
@@ -75,7 +75,8 @@
       },
       "library": {
         "style": "tailwind",
-        "linter": "eslint"
+        "linter": "eslint",
+        "unitTestRunner": "none"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "zustand": "^5.0.4"
   },
   "devDependencies": {
+    "@babel/core": "^7.14.5",
+    "@babel/preset-react": "^7.14.5",
     "@eslint/js": "^9.8.0",
     "@nx/devkit": "20.8.1",
     "@nx/eslint": "20.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,12 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4(@types/react@19.0.0)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
     devDependencies:
+      '@babel/core':
+        specifier: ^7.14.5
+        version: 7.27.1
+      '@babel/preset-react':
+        specifier: ^7.14.5
+        version: 7.27.1(@babel/core@7.27.1)
       '@eslint/js':
         specifier: ^9.8.0
         version: 9.26.0

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,7 +14,9 @@
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
-    "paths": {}
+    "paths": {
+      "@/hooks": ["libs/shared/hooks/src/index.ts"]
+    }
   },
   "exclude": ["node_modules", "tmp"]
 }


### PR DESCRIPTION
This PR introduces two new reusable hooks to the `shared/hooks` library to facilitate working with RxJS observables within React components.

### Added Hooks:

**`useObservableState`:**

* Subscribes to a given RxJS `Observable`.
* Returns the latest emitted value as React state, triggering re-renders when the observable emits.
* Supports an optional `initialValue`.
* Intelligently uses the current value of a `BehaviorSubject` as the initial state if no explicit `initialValue` is provided.

**`useSubscription`:**

* Manages the lifecycle of an RxJS subscription within a component.
* Accepts an `Observable` and an `Observer` object (`{ next, error, complete }`).
* Automatically subscribes when the component mounts (or dependencies change) and unsubscribes when the component unmounts, preventing memory leaks.
* Returns a `RefObject` containing the `Subscription` instance.